### PR TITLE
fix: cx is part of concrete type but not used in parameter list of th…

### DIFF
--- a/motore-macros/src/lib.rs
+++ b/motore-macros/src/lib.rs
@@ -147,7 +147,7 @@ fn expand(item: &mut ItemImpl) -> Result<(), syn::Error> {
     let cx_bound = cx_is_generic.then(|| Some(quote!(Cx: 'cx,))).into_iter();
 
     item.items.push(parse_quote!(
-       type Future<'cx> = impl ::std::future::Future<Output = Result<Self::Response, Self::Error>> + Send
+       type Future<'cx> = impl ::std::future::Future<Output = Result<Self::Response, Self::Error>> + Send + 'cx
         where
             #(#cx_bound)*
             Self:'cx;


### PR DESCRIPTION


## Motivation
fix: `cx` is part of concrete type but not used in parameter list of the `impl Trait` type alias

