### PR TITLE
feat: add adapter between tower and motore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,9 +28,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -37,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -47,15 +53,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -64,15 +70,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -81,21 +87,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -127,6 +133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +156,7 @@ dependencies = [
  "motore-macros",
  "pin-project",
  "tokio",
+ "tower",
 ]
 
 [[package]]
@@ -152,6 +168,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "pin-project"
@@ -214,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -243,6 +265,50 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/motore/Cargo.toml
+++ b/motore/Cargo.toml
@@ -26,7 +26,10 @@ motore-macros = { path = "../motore-macros", version = "0.2" }
 futures = "0.3"
 tokio = { version = "1", features = ["time", "macros"] }
 pin-project = "1"
-
+tower = { version = "0.4", optional = true }
 
 [dev-dependencies]
 http = "0.2"
+
+[features]
+tower = ["dep:tower"]

--- a/motore/src/layer/mod.rs
+++ b/motore/src/layer/mod.rs
@@ -12,7 +12,11 @@ mod identity;
 mod layer_fn;
 mod layers;
 mod stack;
+#[cfg(feature = "tower")]
+mod tower_adapter;
 
+#[cfg(feature = "tower")]
+pub use self::tower_adapter::*;
 pub use self::{
     ext::{LayerExt, MapErrLayer},
     identity::Identity,

--- a/motore/src/layer/tower_adapter.rs
+++ b/motore/src/layer/tower_adapter.rs
@@ -1,0 +1,87 @@
+//! The Adapter layer is used to convert a Motore service into a Tower service and vice versa.
+//!
+//! # Example
+//!
+//! ```rust, ignore
+//! // Convert a Motore service into a Tower service
+//! let tower_service = ServiceBuilder::new()
+//!     .layer(tower_layer)
+//!     .layer(TowerAdapterLayer::new(|tower_req| (cx, motore_req)))
+//!     .service(motore_service);
+//!
+//! // Convert a Tower service into a Motore service
+//! let motore_service = ServiceBuilder::new()
+//!     .layer(motore_layer)
+//!     .layer(TowerAdapterLayer::new(|cx, motore_req| tower_req))
+//!     .service(tower_service);
+
+use std::{fmt, marker::PhantomData};
+
+use super::Layer;
+use crate::service::{Motore, Tower};
+
+pub struct TowerAdapterLayer<F, Cx, MotoreReq> {
+    f: F,
+    _phantom: PhantomData<fn(Cx, MotoreReq)>,
+}
+
+impl<F, Cx, MotoreReq> TowerAdapterLayer<F, Cx, MotoreReq> {
+    pub fn new(f: F) -> Self {
+        Self {
+            f,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<S, F, Cx, MotoreReq> tower::Layer<S> for TowerAdapterLayer<F, Cx, MotoreReq>
+where
+    F: Clone,
+{
+    type Service = Tower<S, F, Cx, MotoreReq>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Tower::new(inner, self.f.clone())
+    }
+}
+
+impl<F, Cx, MotoreReq> Clone for TowerAdapterLayer<F, Cx, MotoreReq>
+where
+    F: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: self.f.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<F, Cx, MotoreReq> fmt::Debug for TowerAdapterLayer<F, Cx, MotoreReq> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TowerAdapterLayer")
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+pub struct MotoreAdapterLayer<F> {
+    f: F,
+}
+
+impl<S, F> Layer<S> for MotoreAdapterLayer<F> {
+    type Service = Motore<S, F>;
+
+    fn layer(self, inner: S) -> Self::Service {
+        Motore::new(inner, self.f)
+    }
+}
+
+impl<F> fmt::Debug for MotoreAdapterLayer<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MotoreAdapterLayer")
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .finish()
+    }
+}

--- a/motore/src/service/mod.rs
+++ b/motore/src/service/mod.rs
@@ -10,9 +10,13 @@ use futures::future::BoxFuture;
 
 mod ext;
 mod service_fn;
+#[cfg(feature = "tower")]
+mod tower_adapter;
 
 pub use ext::*;
 pub use service_fn::{service_fn, ServiceFn};
+#[cfg(feature = "tower")]
+pub use tower_adapter::*;
 
 /// An asynchronous function from a `Request` to a `Response`.
 ///

--- a/motore/src/service/tower_adapter.rs
+++ b/motore/src/service/tower_adapter.rs
@@ -1,0 +1,167 @@
+//! This module provides the Adapter trait, which is used to convert a Motore service into a Tower
+//! service and vice versa.
+//!
+//! Take `TowerAdapter` for example: it will be automatically implemented for any type that
+//! implements `Motore::Service`. Thus, you can use `.tower(f)` method with a closure parameters
+//! passed in to convert a Motore service into a Tower service.
+//!
+//! # Example
+//!
+//! ```rust, ignore
+//! // Convert a Motore service into a Tower service
+//! let tower_service = motore_service.tower(|tower_req| { cx, motore_req });
+//!
+//! // Convert a Tower service into a Motore service
+//! let motore_service = tower_service.motore(|cx, motore_req| { tower_req });
+//! ```
+
+use std::{
+    fmt,
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+use futures::Future;
+
+use crate::Service;
+
+impl<T: ?Sized, Cx, MotoreReq, TowerReq> TowerAdapter<Cx, MotoreReq, TowerReq> for T where
+    T: Service<Cx, MotoreReq>
+{
+}
+
+pub trait TowerAdapter<Cx, MotoreReq, TowerReq>: Service<Cx, MotoreReq> {
+    fn tower<F>(self, f: F) -> Tower<Self, F, Cx, MotoreReq>
+    where
+        F: FnOnce(TowerReq) -> (Cx, MotoreReq),
+        Self: Sized,
+    {
+        Tower::new(self, f)
+    }
+}
+
+pub struct Tower<S, F, Cx, MotoreReq> {
+    inner: S,
+    f: F,
+    _phantom: PhantomData<fn(Cx, MotoreReq)>,
+}
+
+impl<S, F, Cx, MotoreReq> Tower<S, F, Cx, MotoreReq> {
+    pub fn new(inner: S, f: F) -> Self {
+        Self {
+            inner,
+            f,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<S, F, Cx, MotoreReq, TowerReq> tower::Service<TowerReq> for Tower<S, F, Cx, MotoreReq>
+where
+    S: Service<Cx, MotoreReq> + Clone,
+    F: FnOnce(TowerReq) -> (Cx, MotoreReq) + Clone,
+{
+    type Response = S::Response;
+
+    type Error = S::Error;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: TowerReq) -> Self::Future {
+        let inner = self.inner.clone();
+        let (mut cx, r) = (self.f.clone())(req);
+        async move { inner.call(&mut cx, r).await }
+    }
+}
+
+impl<S, F, Cx, MotoreReq> Clone for Tower<S, F, Cx, MotoreReq>
+where
+    S: Clone,
+    F: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            f: self.f.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<S, F, Cx, MotoreReq> fmt::Debug for Tower<S, F, Cx, MotoreReq>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Tower")
+            .field("inner", &self.inner)
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .finish()
+    }
+}
+
+impl<T: ?Sized, Cx, MotoreReq, TowerReq> MotoreAdapter<Cx, MotoreReq, TowerReq> for T where
+    T: tower::Service<TowerReq>
+{
+}
+
+pub trait MotoreAdapter<Cx, MotoreReq, TowerReq>: tower::Service<TowerReq> {
+    fn motore<F>(self, f: F) -> Motore<Self, F>
+    where
+        F: FnOnce(&mut Cx, MotoreReq) -> TowerReq,
+        Self: Sized,
+    {
+        Motore::new(self, f)
+    }
+}
+
+#[derive(Clone)]
+pub struct Motore<S, F> {
+    inner: S,
+    f: F,
+}
+
+impl<S, F> Motore<S, F> {
+    pub fn new(inner: S, f: F) -> Self {
+        Self { inner, f }
+    }
+}
+
+impl<S, F, Cx, MotoreReq, TowerReq> Service<Cx, MotoreReq> for Motore<S, F>
+where
+    S: tower::Service<TowerReq> + Clone,
+    for<'cx> <S as tower::Service<TowerReq>>::Future: 'cx,
+    F: FnOnce(&mut Cx, MotoreReq) -> TowerReq + Clone,
+{
+    type Response = S::Response;
+
+    type Error = S::Error;
+
+    type Future<'cx> = impl Future<Output = Result<Self::Response, Self::Error>> + 'cx
+    where
+        Cx: 'cx,
+        Self: 'cx;
+
+    fn call<'cx, 's>(&'s self, cx: &'cx mut Cx, req: MotoreReq) -> Self::Future<'cx>
+    where
+        's: 'cx,
+    {
+        self.inner.clone().call((self.f.clone())(cx, req))
+    }
+}
+
+impl<S, F> fmt::Debug for Motore<S, F>
+where
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Motore")
+            .field("inner", &self.inner)
+            .field("f", &format_args!("{}", std::any::type_name::<F>()))
+            .finish()
+    }
+}


### PR DESCRIPTION
With the `features = ["tower"]` configured in Cargo.toml, users can convert between tower service and motore sevice easily.