### PR TITLE
feat: remove unnecessary lifetime and announce msrv of 1.77.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@stable
     # - uses: Swatinem/rust-cache@v1
     - name: Run tests
       run: |
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       # - uses: Swatinem/rust-cache@v1
       - name: Run tests
         run: |
@@ -51,7 +51,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v1
     - name: Run tests
       run: |
@@ -63,7 +63,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v1
     - name: Run tests
       run: |
@@ -75,7 +75,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt, clippy
     # - uses: Swatinem/rust-cache@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,15 +19,15 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -40,18 +40,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -67,9 +64,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -82,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -92,15 +89,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -109,38 +106,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -156,15 +153,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
 dependencies = [
  "bytes",
  "fnv",
@@ -173,40 +170,40 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "motore"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "futures",
  "http",
@@ -218,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "motore-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "motore",
  "proc-macro2",
@@ -228,44 +225,44 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -275,18 +272,18 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -319,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -330,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -341,13 +338,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -375,11 +372,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-core",
@@ -387,15 +383,15 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pub trait Service<Cx, Request> {
     type Error;
 
     /// Process the request and return the response asynchronously.
-    async fn call<'s, 'cx>(&'s self, cx: &'cx mut Cx, req: Request) -> Result<Self::Response, Self::Error>;
+    async fn call(&self, cx: &mut Cx, req: Request) -> Result<Self::Response, Self::Error>;
 }
 ```
 
@@ -55,7 +55,7 @@ where
 
     type Error = BoxError;
 
-    async fn call<'s, 'cx>(&'s self, cx: &'cx mut Cx, req: Req) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, cx: &mut Cx, req: Req) -> Result<Self::Response, Self::Error> {
         let sleep = tokio::time::sleep(self.duration);
         tokio::select! {
             r = self.inner.call(cx, req) => {

--- a/motore-macros/Cargo.toml
+++ b/motore-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motore-macros"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = """
 Motore's proc macros.
@@ -10,6 +10,7 @@ readme = "README.md"
 homepage = "https://cloudwego.io/docs/motore/"
 repository = "https://github.com/cloudwego/motore"
 license = "MIT OR Apache-2.0"
+rust-version = "1.77.0"
 authors = ["Motore Team <motore@cloudwego.io>"]
 categories = ["asynchronous"]
 keywords = ["motore", "macro"]

--- a/motore/Cargo.toml
+++ b/motore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motore"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = """
 Motore is a library of modular and reusable components for building robust
@@ -11,6 +11,7 @@ readme = "../README.md"
 homepage = "https://cloudwego.io/docs/motore/"
 repository = "https://github.com/cloudwego/motore"
 license = "MIT OR Apache-2.0"
+rust-version = "1.77.0"
 authors = ["Motore Team <motore@cloudwego.io>"]
 categories = ["asynchronous", "network-programming", "web-programming"]
 keywords = ["io", "async", "non-blocking", "futures", "service"]
@@ -29,7 +30,7 @@ pin-project = "1"
 tower = { version = "0.4", optional = true }
 
 [dev-dependencies]
-http = "0.2"
+http = "1"
 
 [features]
 default = ["service_send"]

--- a/motore/src/layer/layer_fn.rs
+++ b/motore/src/layer/layer_fn.rs
@@ -35,11 +35,7 @@ use super::Layer;
 ///     type Response = S::Response;
 ///     type Error = S::Error;
 ///
-///     async fn call<'s, 'cx>(
-///         &'s self,
-///         cx: &'cx mut Cx,
-///         req: Request,
-///     ) -> Result<Self::Response, Self::Error> {
+///     async fn call(&self, cx: &mut Cx, req: Request) -> Result<Self::Response, Self::Error> {
 ///         // Log the request
 ///         println!("req = {:?}, target = {:?}", req, self.target);
 ///

--- a/motore/src/service/ext/map_err.rs
+++ b/motore/src/service/ext/map_err.rs
@@ -23,17 +23,17 @@ where
     type Error = E;
 
     #[cfg(feature = "service_send")]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: Req,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         self.inner.call(cx, req).map_err(self.f.clone())
     }
     #[cfg(not(feature = "service_send"))]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: Req,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> {
         self.inner.call(cx, req).map_err(self.f.clone())

--- a/motore/src/service/ext/map_response.rs
+++ b/motore/src/service/ext/map_response.rs
@@ -21,17 +21,17 @@ where
     type Error = S::Error;
 
     #[cfg(feature = "service_send")]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: Req,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         self.inner.call(cx, req).map_ok(self.f.clone())
     }
     #[cfg(not(feature = "service_send"))]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: Req,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> {
         self.inner.call(cx, req).map_ok(self.f.clone())

--- a/motore/src/service/mod.rs
+++ b/motore/src/service/mod.rs
@@ -60,9 +60,9 @@ pub use tower_adapter::*;
 ///     type Response = Response<Vec<u8>>;
 ///     type Error = http::Error;
 ///
-///     async fn call<'s, 'cx>(
-///         &'s self,
-///         _cx: &'cx mut Cx,
+///     async fn call(
+///         &self,
+///         _cx: &mut Cx,
 ///         _req: Request<Vec<u8>>,
 ///     ) -> Result<Self::Response, Self::Error> {
 ///         // create the body
@@ -95,17 +95,17 @@ pub trait Service<Cx, Request> {
 
     /// Process the request and return the response asynchronously.
     #[cfg(feature = "service_send")]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: Request,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send;
 
     /// Process the request and return the response asynchronously.
     #[cfg(not(feature = "service_send"))]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: Request,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>>;
 }
@@ -121,17 +121,17 @@ macro_rules! impl_service_ref {
             type Error = T::Error;
 
             #[cfg(feature = "service_send")]
-            fn call<'s, 'cx>(
-                &'s self,
-                cx: &'cx mut Cx,
+            fn call(
+                &self,
+                cx: &mut Cx,
                 req: Req,
             ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
                 (&**self).call(cx, req)
             }
             #[cfg(not(feature = "service_send"))]
-            fn call<'s, 'cx>(
-                &'s self,
-                cx: &'cx mut Cx,
+            fn call(
+                &self,
+                cx: &mut Cx,
                 req: Req,
             ) -> impl Future<Output = Result<Self::Response, Self::Error>> {
                 (&**self).call(cx, req)
@@ -248,17 +248,17 @@ impl<Cx, T, U, E> Service<Cx, T> for BoxService<Cx, T, U, E> {
     type Error = E;
 
     #[cfg(feature = "service_send")]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: T,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         unsafe { (self.vtable.call)(self.raw, cx, req) }
     }
     #[cfg(not(feature = "service_send"))]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: T,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> {
         unsafe { (self.vtable.call)(self.raw, cx, req) }
@@ -366,17 +366,17 @@ impl<Cx, T, U, E> Service<Cx, T> for BoxCloneService<Cx, T, U, E> {
     type Error = E;
 
     #[cfg(feature = "service_send")]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: T,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         unsafe { (self.vtable.call)(self.raw, cx, req) }
     }
     #[cfg(not(feature = "service_send"))]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: T,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> {
         unsafe { (self.vtable.call)(self.raw, cx, req) }

--- a/motore/src/service/service_fn.rs
+++ b/motore/src/service/service_fn.rs
@@ -49,9 +49,9 @@ where
     type Response = R;
     type Error = E;
 
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: Request,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> {
         (self.f).call(cx, req)

--- a/motore/src/service/tower_adapter.rs
+++ b/motore/src/service/tower_adapter.rs
@@ -178,18 +178,18 @@ where
     type Error = S::Error;
 
     #[cfg(feature = "service_send")]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: MotoreReq,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send {
         self.inner.clone().call((self.f.clone())(cx, req))
     }
 
     #[cfg(not(feature = "service_send"))]
-    fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
+    fn call(
+        &self,
+        cx: &mut Cx,
         req: MotoreReq,
     ) -> impl Future<Output = Result<Self::Response, Self::Error>> {
         self.inner.clone().call((self.f.clone())(cx, req))

--- a/motore/src/timeout.rs
+++ b/motore/src/timeout.rs
@@ -29,11 +29,7 @@ where
 
     type Error = BoxError;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
-        req: Req,
-    ) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, cx: &mut Cx, req: Req) -> Result<Self::Response, Self::Error> {
         match self.duration {
             Some(duration) => {
                 let sleep = tokio::time::sleep(duration);

--- a/motore/src/utils/either.rs
+++ b/motore/src/utils/either.rs
@@ -37,11 +37,7 @@ where
 
     type Error = A::Error;
 
-    async fn call<'s, 'cx>(
-        &'s self,
-        cx: &'cx mut Cx,
-        req: Req,
-    ) -> Result<Self::Response, Self::Error> {
+    async fn call(&self, cx: &mut Cx, req: Req) -> Result<Self::Response, Self::Error> {
         match self {
             Either::A(s) => s.call(cx, req).await,
             Either::B(s) => s.call(cx, req).await,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-# TODO: we can remove this toolchain file when AFIT and RPITIT hits stable.
-channel = "nightly"


### PR DESCRIPTION
## Motivation

Previously we explicitly marked the lifetime of `&self` and `&mut Cx` because we used `TAIT` before, but since we switched to `RPITIT` and `AFIT` now we don't need it anymore.

According to the [lifetime captures rules](https://github.com/rust-lang/rfcs/blob/master/text/3498-lifetime-capture-rules-2024.md), the Future will automatically captures the lifetime of `&self` and `&mut Cx`.

## Solution

Remove the unnecessary lifetimes.

## Misc

This PR also announces a MSRV of 1.77.0(currently latest rust version).
