### PR TITLE
chore: fix error message construction

### DIFF
--- a/motore-macros/src/lib.rs
+++ b/motore-macros/src/lib.rs
@@ -34,7 +34,7 @@ pub fn service(_args: TokenStream, input: TokenStream) -> TokenStream {
     let mut item = parse_macro_input!(input as ItemImpl);
 
     if let Err(err) = expand(&mut item) {
-        return syn::Error::into_compile_error(err).into();
+        return err.into_compile_error().into();
     }
 
     TokenStream::from(quote!(#item))


### PR DESCRIPTION
## Motivation

errors when using motore-macros in https://github.com/apache/iceberg-rust/pull/1294
```
error[E0599]: no function or associated item named `into_compile_error` found for struct `syn::Error` in the current scope
   --> patches/motore-macros/src/lib.rs:38:28
    |
38  |         return syn::Error::into_compile_error(err).into();
    |                            ^^^^^^^^^^^^^^^^^^ function or associated item not found in `syn::Error`
    |
note: if you're trying to build a new `syn::Error` consider using one of the following associated functions:
      syn::Error::new
      syn::Error::new_spanned
   --> /home/sundy/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/syn-1.0.44/src/error.rs:133:5
    |
133 |     pub fn new<T: Display>(span: Span, message: T) -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
157 |     pub fn new_spanned<T: ToTokens, U: Display>(tokens: T, message: U) -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: there is a method `to_compile_error` with a similar name, but with different arguments
   --> /home/sundy/.cargo/registry/src/mirrors.tuna.tsinghua.edu.cn-df7c3c540f42cdbd/syn-1.0.44/src/error.rs:193:5
    |
193 |     pub fn to_compile_error(&self) -> TokenStream {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
error: could not compile `motore-macros` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

## Solution

fix the construction function of error
