### PR TITLE
refactor: Deprecate #[motore::service] macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "motore"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "futures",
  "http",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "motore-macros"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "motore",
  "proc-macro2",

--- a/README.md
+++ b/README.md
@@ -68,28 +68,6 @@ where
 }
 ```
 
-We also provided the `#[motore::service]` macro to make writing a `Serivce` more async-native:
-
-```rust
-use motore::service;
-
-pub struct S<I> {
-    inner: I,
-}
-
-#[service]
-impl<Cx, Req, I> Service<Cx, Req> for S<I>
-where
-   Req: Send + 'static,
-   I: Service<Cx, Req> + Send + 'static + Sync,
-   Cx: Send + 'static,
-{
-    async fn call(&self, cx: &mut Cx, req: Req) -> Result<I::Response, I::Error> {
-        self.inner.call(cx, req).await
-    }
-}
-```
-
 ## FAQ
 
 ### Where's the `poll_ready`(a.k.a. backpressure)?

--- a/motore-macros/Cargo.toml
+++ b/motore-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motore-macros"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = """
 Motore's proc macros.

--- a/motore-macros/src/lib.rs
+++ b/motore-macros/src/lib.rs
@@ -29,6 +29,9 @@ use syn::{parse_macro_input, parse_quote, spanned::Spanned, ItemImpl, PatType, T
 ///     }
 /// }
 /// ```
+#[deprecated(
+    note = "The `service` macro is no longer needed as `async fn in trait` are now stable. You can write `async fn call` directly in your `Service` implementation without this macro."
+)]
 #[proc_macro_attribute]
 pub fn service(_args: TokenStream, input: TokenStream) -> TokenStream {
     let mut item = parse_macro_input!(input as ItemImpl);

--- a/motore/Cargo.toml
+++ b/motore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "motore"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = """
 Motore is a library of modular and reusable components for building robust

--- a/motore/src/lib.rs
+++ b/motore/src/lib.rs
@@ -43,6 +43,9 @@ pub mod make;
 pub mod service;
 pub mod timeout;
 pub mod utils;
+#[deprecated(
+    note = "`async fn in trait` is stable now. You can use `async fn call` directly in your `Service` implementation without this macro."
+)]
 pub use motore_macros::service;
 pub use service::{BoxCloneService, Service, ServiceExt, UnaryService};
 
@@ -58,6 +61,7 @@ mod sealed {
 mod tests {
 
     #[test]
+    #[allow(deprecated)]
     pub fn test_service_macro() {
         pub struct Context;
         pub struct Service<S>(S);


### PR DESCRIPTION

**Motivation**

Now that `async fn in trait` (AFIT) is stable in Rust, the `#[motore::service]` macro is no longer necessary. This macro was originally created as a workaround to provide an `async fn`-like developer experience by desugaring it into the `fn call(...) -> impl Future` signature required by the `Service` trait.

Since the Rust compiler can now handle this conversion automatically, we should deprecate the macro and encourage users to implement `async fn call` directly.

**Solution**

This PR deprecates the macro and removes its documentation:

1.  **`motore-macros/src/lib.rs`**: Added `#[deprecated]` to the macro definition with a note explaining why it's no longer needed.
2.  **`motore/src/lib.rs`**: Added `#[deprecated]` to the re-exported `service` macro.
3.  **`motore/src/lib.rs`**: Added `#[allow(deprecated)]` to `test_service_macro` to prevent CI failures from our own deprecation warning.
4.  **`README.md`**: Removed the entire section and all examples related to the `#[motore::service]` macro. The existing "Getting Started" example for `Timeout` already serves as a perfect, macro-less example of how to implement the trait.

**Related**
1.  https://github.com/cloudwego/cloudwego.github.io/pull/1451#discussion_r2468269042