### PR TITLE
fix(ci): migrate all self-hosted ci runner to github-hosted

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - run: exit 0
 
   test-linux:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
         cargo test
 
   test-linux-aarch64:
-    runs-on: [self-hosted, Linux, aarch64]
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
           cargo test
 
   test-macos:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
         cargo test
 
   test-windows:
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
         cargo test
 
   lint:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -7,7 +7,7 @@ on:
       - '**/Cargo.lock'
 jobs:
   security-audit:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Change-Id: I88aa289af1733bf45b069068fc61d4708cab3bb1

## Motivation

All self-hosted ci runners will be deprecated soon.

## Solution

Migrate all self-hosted ci runners to github-hosted ones.